### PR TITLE
Parameterize data and log paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Data Engineering In Action
+
+This project contains utilities for loading and analyzing credit card and loan data.
+
+## Base Directory
+
+Scripts look for data files and store generated visualizations relative to a base directory. By default this is the repository location, but it can be overridden with the `CAPSTONE_HOME` environment variable.
+
+Example:
+
+```bash
+export CAPSTONE_HOME=/opt/capstone
+python main.py
+```
+
+Data files should be stored in `$CAPSTONE_HOME/data` and visualizations will be written to `$CAPSTONE_HOME/logs/visualizations`.

--- a/cli_app/visualizer.py
+++ b/cli_app/visualizer.py
@@ -4,6 +4,13 @@ import os
 import datetime
 import pandas as pd
 
+# Base directory for saving visualizations
+CAPSTONE_HOME = os.getenv(
+    "CAPSTONE_HOME",
+    os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+DEFAULT_LOG_FOLDER = os.path.join(CAPSTONE_HOME, "logs", "visualizations")
+
 def ask_for_visualization(df, title, log_folder=None):
     """Visualize dataframe columns using various chart types.
 
@@ -20,7 +27,7 @@ def ask_for_visualization(df, title, log_folder=None):
         return
 
     if log_folder is None:
-        log_folder = r"C:\Users\timothy.pluimer\Downloads\Capstone\logs\visualizations"
+        log_folder = DEFAULT_LOG_FOLDER
     os.makedirs(log_folder, exist_ok=True)
 
     print("\nChoose a visualization type:")

--- a/etl/load_json_to_mysql.py
+++ b/etl/load_json_to_mysql.py
@@ -4,6 +4,12 @@ from pyspark.sql.types import StringType
 import re
 import os
 
+# Base directory for input data
+CAPSTONE_HOME = os.getenv(
+    "CAPSTONE_HOME", os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+DATA_DIR = os.path.join(CAPSTONE_HOME, "data")
+
 DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_PORT = os.getenv("DB_PORT", "3306")
 DB_USER = os.getenv("DB_USER", "root")
@@ -29,7 +35,9 @@ def format_phone(phone):
 format_phone_udf = udf(format_phone, StringType()) # Register the UDF
 
 # CUSTOMER ETL
-customer_df = spark.read.option("multiLine", True).json(r"C:\Users\timothy.pluimer\Downloads\Capstone\data\cdw_sapp_customer.json") # Load the JSON file
+customer_df = spark.read.option("multiLine", True).json(
+    os.path.join(DATA_DIR, "cdw_sapp_customer.json")
+)  # Load the JSON file
 # Transform the customer data
 transformed_customer = customer_df \
     .withColumn("FIRST_NAME", initcap(col("FIRST_NAME"))) \
@@ -44,7 +52,9 @@ transformed_customer = customer_df \
     )
 
 # BRANCH ETL
-branch_df = spark.read.option("multiLine", True).json(r"C:\Users\timothy.pluimer\Downloads\Capstone\data\cdw_sapp_branch.json")
+branch_df = spark.read.option("multiLine", True).json(
+    os.path.join(DATA_DIR, "cdw_sapp_branch.json")
+)
 # Transform the branch data
 transformed_branch = branch_df \
     .withColumn("BRANCH_PHONE", format_phone_udf(col("BRANCH_PHONE"))) \
@@ -55,7 +65,9 @@ transformed_branch = branch_df \
     )
 
 # CREDIT CARD ETL
-credit_df = spark.read.option("multiLine", True).json(r"C:\Users\timothy.pluimer\Downloads\Capstone\data\cdw_sapp_credit.json")
+credit_df = spark.read.option("multiLine", True).json(
+    os.path.join(DATA_DIR, "cdw_sapp_credit.json")
+)
 # Transform the credit card data
 transformed_credit = credit_df \
     .withColumn("TIMEID",

--- a/etl/loan_api_to_mysql.py
+++ b/etl/loan_api_to_mysql.py
@@ -4,6 +4,11 @@ import mysql.connector as dbconnect
 from mysql.connector import errorcode
 import os
 
+# Optional base directory for future data storage
+CAPSTONE_HOME = os.getenv(
+    "CAPSTONE_HOME", os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+
 DB_HOST = os.getenv("DB_HOST", "localhost")
 DB_PORT = int(os.getenv("DB_PORT", "3306"))
 DB_USER = os.getenv("DB_USER", "root")

--- a/main.py
+++ b/main.py
@@ -5,6 +5,12 @@ from tabulate import tabulate
 import os
 from cli_app.visualizer import ask_for_visualization
 
+# Determine base directory for logs and data
+CAPSTONE_HOME = os.getenv(
+    "CAPSTONE_HOME", os.path.dirname(os.path.abspath(__file__))
+)
+LOG_FOLDER = os.path.join(CAPSTONE_HOME, "logs", "visualizations")
+
 def clear_screen(): # defines a function to clear the terminal screen
     os.system('cls' if os.name == 'nt' else 'clear')
 
@@ -64,7 +70,7 @@ def transaction_details(): # defines a function to retrieve and display transact
             print(f"\n--- Transactions in ZIP {zip_code} for {month}/{year} ---") # print header for the transaction details
             print(tabulate(df, headers='keys', tablefmt='psql', showindex=False)) # print the DataFrame in a pretty table format
 
-            ask_for_visualization(df, title="Transaction Details", log_folder=r"C:\Users\timothy.pluimer\Downloads\Capstone\logs\visualizations") # ask for visualization of the DataFrame
+            ask_for_visualization(df, title="Transaction Details", log_folder=LOG_FOLDER)  # ask for visualization of the DataFrame
 
         cursor.close() # close the cursor
         conn.close() # close the database connection
@@ -115,7 +121,7 @@ def view_customer_details(): # defines a function to view customer details based
             print("\n--- Customer Details ---") # print header for the customer details
             print(tabulate(df, headers="keys", tablefmt="psql", showindex=False)) # print the DataFrame in a pretty table format
 
-            ask_for_visualization(df, title="Customer Details", log_folder=r"C:\Users\timothy.pluimer\Downloads\Capstone\logs\visualizations") # ask for visualization of the DataFrame
+            ask_for_visualization(df, title="Customer Details", log_folder=LOG_FOLDER)  # ask for visualization of the DataFrame
         else: 
             print("Customer not found.")
             df = pd.DataFrame()
@@ -168,7 +174,7 @@ def modify_customer_details(): # defines a function to modify customer details b
             print("\n--- Updated Customer Details ---")
             print(tabulate(df, headers="keys", tablefmt="psql", showindex=False)) # print the DataFrame in a pretty table format
             # Ask for visualization of the updated customer details 
-            ask_for_visualization(df, title="Updated Customer Details", log_folder=r"C:\Users\timothy.pluimer\Downloads\Capstone\logs\visualizations")
+            ask_for_visualization(df, title="Updated Customer Details", log_folder=LOG_FOLDER)
         cursor.close()
         conn.close()
         pause()
@@ -198,7 +204,7 @@ def generate_monthly_bill(): # defines a function to generate the monthly bill f
             print(f"\nTotal bill for {month}/{year}:") # print header for the monthly bill
             print(tabulate(df, headers="keys", tablefmt="psql", showindex=False)) # print the DataFrame in a pretty table format
 
-            ask_for_visualization(df, title="Monthly Bill Summary", log_folder=r"C:\Users\timothy.pluimer\Downloads\Capstone\logs\visualizations")
+            ask_for_visualization(df, title="Monthly Bill Summary", log_folder=LOG_FOLDER)
         else:
             print("No transactions found.")
             df = pd.DataFrame()
@@ -259,7 +265,7 @@ def customer_transactions_date_range(): # defines a function to retrieve custome
             print(f"\n--- Transactions for Credit Card {cc_num} from {start_date} to {end_date} ---") # print header for the transaction details
             print(tabulate(df, headers="keys", tablefmt="psql", showindex=False)) # print the DataFrame in a pretty table format
 
-            ask_for_visualization(df, title="Customer Transactions by Date Range", log_folder=r"C:\Users\timothy.pluimer\Downloads\Capstone\logs\visualizations")
+            ask_for_visualization(df, title="Customer Transactions by Date Range", log_folder=LOG_FOLDER)
         else:
             print("No transactions found for that period.")
             df = pd.DataFrame()

--- a/visualizations/visualization_creation.py
+++ b/visualizations/visualization_creation.py
@@ -2,16 +2,23 @@ import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 import geopandas as gpd
+import os
+
+# Determine base directory for data files
+CAPSTONE_HOME = os.getenv(
+    "CAPSTONE_HOME", os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+)
+DATA_DIR = os.path.join(CAPSTONE_HOME, "data")
 
 # Set Seaborn style
 sns.set(style="whitegrid")
 
 # === LOAD FILES ===
 try:
-    loan_df = pd.read_json(r"C:\Users\timothy.pluimer\Downloads\Capstone\data\cdw_sapp_loan_data.json")
-    credit_df = pd.read_json(r"C:\Users\timothy.pluimer\Downloads\Capstone\data\cdw_sapp_credit.json")
-    customer_df = pd.read_json(r"C:\Users\timothy.pluimer\Downloads\Capstone\data\cdw_sapp_customer.json")
-    branch_df = pd.read_json(r"C:\Users\timothy.pluimer\Downloads\Capstone\data\cdw_sapp_branch.json")
+    loan_df = pd.read_json(os.path.join(DATA_DIR, "cdw_sapp_loan_data.json"))
+    credit_df = pd.read_json(os.path.join(DATA_DIR, "cdw_sapp_credit.json"))
+    customer_df = pd.read_json(os.path.join(DATA_DIR, "cdw_sapp_customer.json"))
+    branch_df = pd.read_json(os.path.join(DATA_DIR, "cdw_sapp_branch.json"))
     print("All files loaded successfully.")
 except Exception as e:
     print(f"Error loading files: {e}")
@@ -41,7 +48,7 @@ except Exception as e:
 # === FIXED: TOP 10 STATES BY CUSTOMER COUNT ===
 
 # Load Customer Data
-customer_df = pd.read_json(r"C:\Users\timothy.pluimer\Downloads\Capstone\data\cdw_sapp_customer.json")
+customer_df = pd.read_json(os.path.join(DATA_DIR, "cdw_sapp_customer.json"))
 
 # Count Customers by State & Select Top 10
 state_counts = customer_df["CUST_STATE"].value_counts().reset_index()
@@ -71,7 +78,7 @@ plt.show()
 # === Highest Count Transaction Types ===
 
 # Load transaction data
-credit_df = pd.read_json(r"C:\Users\timothy.pluimer\Downloads\Capstone\data\cdw_sapp_credit.json")
+credit_df = pd.read_json(os.path.join(DATA_DIR, "cdw_sapp_credit.json"))
 
 # Group by Transaction Type & Count
 transaction_counts = credit_df["TRANSACTION_TYPE"].value_counts()


### PR DESCRIPTION
## Summary
- add README documenting CAPSTONE_HOME usage
- parameterize visualization paths in main app
- make visualizer use environment-based log directory
- update ETL scripts to read data via CAPSTONE_HOME
- document base directory support in visualization creation

## Testing
- `python -m py_compile main.py cli_app/visualizer.py etl/load_json_to_mysql.py etl/loan_api_to_mysql.py visualizations/visualization_creation.py`

------
https://chatgpt.com/codex/tasks/task_e_68488e4e403883249b2bd866c4d33b6d