### PR TITLE
Add asset download instructions and ignore data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ logs/
 
 # Ignore all .pptx files
 *.pptx
+
+# Ignore data files and screenshots
+data/
+screenshots/

--- a/README.md
+++ b/README.md
@@ -202,3 +202,13 @@ These values are used by `main.py` and the ETL scripts when establishing a
 database connection.
 >>>>>>> master
 >>>>>>> codex/replace-absolute-windows-paths-with-configurable-ones
+
+## Downloading Sample Data and Visualizations
+To keep the repository small, the `data/` and `screenshots/` folders are not tracked in git. Use the helper script below to download and extract them:
+
+```bash
+bash scripts/download_assets.sh
+```
+
+Set the `ASSETS_URL` environment variable to point to an archive containing both directories if you host them elsewhere. Alternatively, run `python data/api_save.py` to fetch the loan dataset directly from its source.
+

--- a/scripts/download_assets.sh
+++ b/scripts/download_assets.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Download the data and screenshots archives and extract them.
+
+set -euo pipefail
+
+ASSETS_URL=${ASSETS_URL:-"https://example.com/assets.tar.gz"}
+
+curl -L "$ASSETS_URL" -o assets.tar.gz
+
+tar -xzf assets.tar.gz
+
+echo "Assets downloaded and extracted."


### PR DESCRIPTION
## Summary
- ignore `data/` and `screenshots/` so large assets don't end up in git
- add a helper script for downloading external assets
- document how to obtain the sample data and screenshots

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684988bbd9e08324bf6bbd2dc7af4cb6