### PR TITLE
Add center logo across pages

### DIFF
--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -15,6 +15,7 @@
         </a>
     </header>
     <div class="container">
+        <img src="{{ url_for('static', filename='logo.png') }}" alt="CDW Sapp Logo" class="center-logo">
         {% block content %}{% endblock %}
     </div>
 </body>


### PR DESCRIPTION
## Summary
- display center logo on all templates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ad6e520c08324b3e29dcef26ef09c