### PR TITLE
Add detailed monthly bill view to web app

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -52,16 +52,18 @@ def transactions():
 
 @app.route('/monthly_bill', methods=['GET', 'POST'])
 def monthly_bill():
+    transactions = None
     total = None
     if request.method == 'POST':
         cc_num = request.form.get('cc_num')
         month = request.form.get('month')
         year = request.form.get('year')
         if cc_num and month and year:
-            result = generate_monthly_bill(cc_num, int(month), int(year))
-            if result is not None:
-                total = f"${result:.2f}"
-    return render_template('monthly_bill.html', total=total)
+            df, total_val = generate_monthly_bill(cc_num, int(month), int(year))
+            if not df.empty:
+                transactions = df.to_dict(orient='records')
+                total = f"${total_val:.2f}"
+    return render_template('monthly_bill.html', transactions=transactions, total=total)
 
 
 @app.route('/modify_customer', methods=['GET', 'POST'])

--- a/web/templates/monthly_bill.html
+++ b/web/templates/monthly_bill.html
@@ -11,7 +11,27 @@
     <input type="text" name="year" required>
     <button type="submit">Generate</button>
 </form>
+
+{% if transactions %}
+<table>
+    <tr>
+        {% for key in transactions[0].keys() %}
+            <th>{{ key }}</th>
+        {% endfor %}
+    </tr>
+    {% for row in transactions %}
+    <tr>
+        {% for val in row.values() %}
+        <td>{{ val }}</td>
+        {% endfor %}
+    </tr>
+    {% endfor %}
+</table>
+{% elif total is not none %}
+<p>No transactions found.</p>
+{% endif %}
+
 {% if total %}
-<p>Total Bill: {{ total }}</p>
+<p>Total Charges: {{ total }}</p>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- enhance `generate_monthly_bill` in `db/utils.py` to return transaction details and total
- display monthly bill transactions on the website

## Testing
- `python -m py_compile db/utils.py web/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684add1a5f948324a149bce21006ec6c