### PR TITLE
Improve web monthly bill display

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -54,6 +54,9 @@ def transactions():
 def monthly_bill():
     transactions = None
     total = None
+    month = None
+    year = None
+    masked_cc = None
     if request.method == 'POST':
         cc_num = request.form.get('cc_num')
         month = request.form.get('month')
@@ -63,7 +66,15 @@ def monthly_bill():
             if not df.empty:
                 transactions = df.to_dict(orient='records')
                 total = f"${total_val:.2f}"
-    return render_template('monthly_bill.html', transactions=transactions, total=total)
+                masked_cc = f"**** **** **** {cc_num[-4:]}"
+    return render_template(
+        'monthly_bill.html',
+        transactions=transactions,
+        total=total,
+        month=month,
+        year=year,
+        masked_cc=masked_cc,
+    )
 
 
 @app.route('/modify_customer', methods=['GET', 'POST'])

--- a/web/static/style.css
+++ b/web/static/style.css
@@ -79,3 +79,21 @@ th {
 .center-logo:hover {
     transform: scale(1.15);
 }
+
+.bill-statement {
+    margin-top: 20px;
+}
+
+.bill-statement h2 {
+    margin-bottom: 5px;
+}
+
+.bill-statement p {
+    margin: 2px 0;
+    font-weight: 700;
+}
+
+.total {
+    font-weight: bold;
+    margin-top: 10px;
+}

--- a/web/templates/monthly_bill.html
+++ b/web/templates/monthly_bill.html
@@ -13,7 +13,13 @@
 </form>
 
 {% if transactions %}
-<table>
+<div class="bill-statement">
+    <h2>CDW Sapp Bank Statement</h2>
+    <p>Billing Period: {{ month }}/{{ year }}</p>
+    <p>Credit Card #: {{ masked_cc }}</p>
+</div>
+
+<table class="table">
     <tr>
         {% for key in transactions[0].keys() %}
             <th>{{ key }}</th>
@@ -27,11 +33,9 @@
     </tr>
     {% endfor %}
 </table>
+
+<p class="total">Total Charges: {{ total }}</p>
 {% elif total is not none %}
 <p>No transactions found.</p>
-{% endif %}
-
-{% if total %}
-<p>Total Charges: {{ total }}</p>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- provide billing period and masked card details on monthly bill page
- show statement heading with table styling
- style the statement header and total charge section

## Testing
- `python -m py_compile web/app.py`
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684ae2f3ad3c8324bb78ada5c442ba66