### PR TITLE
Simplify header logo placement

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -45,7 +45,8 @@ th {
     color: white;
     display: flex;
     align-items: center;
-    padding: 10px 20px;
+    justify-content: center;
+    padding: 5px 0;
 }
 
 .home-link {
@@ -53,27 +54,15 @@ th {
     align-items: center;
 }
 
-.header-logo {
-    height: 50px;
-    width: auto;
-    margin-right: 15px;
-    transition: transform 0.3s ease;
-}
-
-.header-logo:hover {
-    transform: scale(1.1);
-}
-
-.site-title {
-    font-size: 1.5em;
-    font-weight: bold;
-    color: #ff6600;
-}
 
 .center-logo {
     width: 150px;
     margin-bottom: 20px;
     transition: transform 0.3s ease;
+}
+
+.site-header .center-logo {
+    margin-bottom: 0;
 }
 
 .center-logo:hover {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -10,14 +10,10 @@
 <body>
     <header class="site-header">
         <a href="{{ url_for('home') }}" class="home-link">
-            <img src="{{ url_for('static', filename='logo.png') }}" alt="Bank Logo" class="header-logo">
-            <span class="site-title">CDW Sapp</span>
+            <img src="{{ url_for('static', filename='logo.png') }}" alt="CDW Sapp Logo" class="center-logo">
         </a>
     </header>
     <div class="container">
-        <a href="{{ url_for('home') }}">
-        <img src="{{ url_for('static', filename='logo.png') }}" alt="CDW Sapp Logo" class="center-logo">
-        </a>
         {% block content %}{% endblock %}
     </div>
 </body>


### PR DESCRIPTION
## Summary
- center the logo in the header and remove the site title
- drop unused CSS for the old header logo
- use minimal padding for the header

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b09c9101083249019e539b588fb55