### PR TITLE
Center logo link and shrink click box

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -50,8 +50,9 @@ th {
 }
 
 .home-link {
-    display: flex;
-    align-items: center;
+    display: inline-block;
+    padding: 1px;
+    margin: 0 auto;
 }
 
 


### PR DESCRIPTION
## Summary
- reduce clickable area around the header logo
- center logo link within header

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b176da9688324a8f3f334f08e206b