### PR TITLE
Add reusable visualization helper and web routes

### DIFF
--- a/cli_app/visualizer.py
+++ b/cli_app/visualizer.py
@@ -11,6 +11,76 @@ CAPSTONE_HOME = os.getenv(
 )
 DEFAULT_LOG_FOLDER = os.path.join(CAPSTONE_HOME, "logs", "visualizations")
 
+
+def generate_visualization(df, chart_type, x_col=None, y_col=None):
+    """Return a matplotlib figure for the requested chart type."""
+
+    plt.figure(figsize=(10, 6))
+
+    if chart_type in {"bar", "line", "scatter"}:
+        if x_col is None or y_col is None:
+            raise ValueError("x_col and y_col must be provided for this chart type")
+        if not pd.api.types.is_numeric_dtype(df[y_col]):
+            raise ValueError(f"Column '{y_col}' is not numeric")
+
+        if chart_type == "bar":
+            df.groupby(x_col)[y_col].sum().plot(kind="bar")
+            plt.title(f"Bar Chart: {y_col} by {x_col}")
+        elif chart_type == "line":
+            plt.plot(df[x_col], df[y_col], marker="o")
+            plt.title(f"Line Chart: {y_col} over {x_col}")
+        else:  # scatter
+            plt.scatter(df[x_col], df[y_col])
+            plt.title(f"Scatter Plot: {y_col} vs {x_col}")
+
+        plt.xlabel(x_col)
+        plt.ylabel(y_col)
+
+    elif chart_type == "pie":
+        if x_col is None:
+            raise ValueError("x_col must be provided for pie chart")
+        df[x_col].value_counts().plot(kind="pie", autopct="%1.1f%%", startangle=90)
+        plt.title(f"Pie Chart of {x_col}")
+        plt.ylabel("")
+
+    elif chart_type == "hist":
+        if x_col is None:
+            raise ValueError("x_col must be provided for histogram")
+        if not pd.api.types.is_numeric_dtype(df[x_col]):
+            raise ValueError(f"Column '{x_col}' is not numeric")
+        df[x_col].plot(kind="hist", bins=10, edgecolor="black")
+        plt.title(f"Histogram of {x_col}")
+        plt.xlabel(x_col)
+
+    elif chart_type == "box":
+        if x_col is None:
+            raise ValueError("x_col must be provided for box plot")
+        if not pd.api.types.is_numeric_dtype(df[x_col]):
+            raise ValueError(f"Column '{x_col}' is not numeric")
+        sns.boxplot(data=df[[x_col]])
+        plt.title(f"Box Plot of {x_col}")
+
+    elif chart_type == "heatmap":
+        corr = df.select_dtypes(include="number").corr()
+        sns.heatmap(corr, annot=True, cmap="coolwarm")
+        plt.title("Heatmap of Correlations")
+
+    elif chart_type == "grouped_bar":
+        if x_col is None or y_col is None:
+            raise ValueError("x_col and y_col must be provided for grouped_bar")
+        if not pd.api.types.is_numeric_dtype(df[y_col]):
+            raise ValueError(f"Column '{y_col}' is not numeric")
+        df.groupby(x_col)[y_col].sum().plot(kind="bar")
+        plt.title(f"Grouped Bar Chart: {y_col} by {x_col}")
+        plt.xlabel(x_col)
+        plt.ylabel(y_col)
+
+    else:
+        raise ValueError("Unsupported chart type")
+
+    plt.tight_layout()
+    return plt.gcf()
+
 def ask_for_visualization(df, title, log_folder=None):
     """Visualize dataframe columns using various chart types.
 
@@ -70,94 +140,43 @@ def ask_for_visualization(df, title, log_folder=None):
                 print("Please enter a valid number.")
 
     try:
-        if option in ['1', '2', '3']:  # Bar, Line, Scatter
-            x_idx = get_column_index("Enter number for X-axis column: ")
-            y_idx = get_column_index("Enter number for Y-axis column: ")
-            x, y = all_columns[x_idx], all_columns[y_idx]
+        chart_map = {
+            '1': 'bar',
+            '2': 'line',
+            '3': 'scatter',
+            '4': 'pie',
+            '5': 'hist',
+            '6': 'box',
+            '7': 'heatmap',
+            '8': 'grouped_bar'
+        }
 
-            if not pd.api.types.is_numeric_dtype(df[y]):
-                print(f"Column '{y}' is not numeric. Cannot plot {viz_options[option]}.")
-                return
-
-            if option == '1':
-                df.groupby(x)[y].sum().plot(kind='bar')
-                plt.title(f"Bar Chart: {y} by {x}")
-            elif option == '2':
-                plt.plot(df[x], df[y], marker='o')
-                plt.title(f"Line Chart: {y} over {x}")
-            elif option == '3':
-                plt.scatter(df[x], df[y])
-                plt.title(f"Scatter Plot: {y} vs {x}")
-
-            plt.xlabel(x)
-            plt.ylabel(y)
-
-        elif option == '4':  # Pie Chart
-            col_idx = get_column_index("Enter number for column: ")
-            col = all_columns[col_idx]
-            df[col].value_counts().plot(kind='pie', autopct='%1.1f%%', startangle=90)
-            plt.title(f"Pie Chart of {col}")
-            plt.ylabel('')  # Hide y-axis
-
-        elif option == '5':  # Histogram
-            col_idx = get_column_index("Enter number for column: ")
-            col = all_columns[col_idx]
-
-            if not pd.api.types.is_numeric_dtype(df[col]):
-                print(f"Column '{col}' is not numeric. Cannot plot histogram.")
-                return
-
-            df[col].plot(kind='hist', bins=10, edgecolor='black')
-            plt.title(f"Histogram of {col}")
-            plt.xlabel(col)
-
-        elif option == '6':  # Box Plot
-            col_idx = get_column_index("Enter number for column: ")
-            col = all_columns[col_idx]
-
-            if not pd.api.types.is_numeric_dtype(df[col]):
-                print(f"Column '{col}' is not numeric. Cannot plot boxplot.")
-                return
-
-            sns.boxplot(data=df[[col]])
-            plt.title(f"Box Plot of {col}")
-
-        elif option == '7':  # Heatmap
-            print("Using correlation matrix of numeric columns.")
-            corr = df.select_dtypes(include='number').corr()
-            sns.heatmap(corr, annot=True, cmap="coolwarm")
-            plt.title("Heatmap of Correlations")
-
-        elif option == '8':  # Grouped Bar Chart
-            group_idx = get_column_index("Enter number for X-axis (categorical) column: ")
-            value_idx = get_column_index("Enter number for Y-axis (numeric) column: ")
-            group_col, value_col = all_columns[group_idx], all_columns[value_idx]
-
-            if not pd.api.types.is_numeric_dtype(df[value_col]):
-                print(f"Column '{value_col}' is not numeric. Cannot plot grouped bar chart.")
-                return
-
-            df.groupby(group_col)[value_col].sum().plot(kind='bar')
-            plt.title(f"Grouped Bar Chart: {value_col} by {group_col}")
-            plt.xlabel(group_col)
-            plt.ylabel(value_col)
-
-        else:
+        chart_type = chart_map.get(option)
+        if not chart_type:
             print("Invalid option selected.")
             return
 
-        plt.tight_layout()
+        x = y = None
+        if chart_type in {"bar", "line", "scatter", "grouped_bar"}:
+            x_idx = get_column_index("Enter number for X-axis column: ")
+            y_idx = get_column_index("Enter number for Y-axis column: ")
+            x, y = all_columns[x_idx], all_columns[y_idx]
+        elif chart_type in {"pie", "hist", "box"}:
+            col_idx = get_column_index("Enter number for column: ")
+            x = all_columns[col_idx]
+
+        fig = generate_visualization(df, chart_type, x, y)
 
         save_choice = input("\nWould you like to save this visualization? (1 for Yes, 2 for No): ").strip()
 
         if save_choice == '1':
             timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
             filename = os.path.join(log_folder, f"visualization_{timestamp}.png")
-            plt.savefig(filename)
+            fig.savefig(filename)
             print(f"\nVisualization saved as: {filename}")
 
         plt.show()
-        plt.close()
+        plt.close(fig)
 
     except Exception as e:
         print(f"Error generating visualization: {e}")

--- a/web/app.py
+++ b/web/app.py
@@ -1,7 +1,11 @@
-from flask import Flask, render_template, request
+from flask import Flask, render_template, request, send_from_directory
 
 from db.utils import connect_to_db, generate_monthly_bill, modify_customer
+from cli_app.visualizer import generate_visualization, CAPSTONE_HOME
 import pandas as pd
+import os
+import datetime
+import matplotlib.pyplot as plt
 
 app = Flask(__name__)
 
@@ -46,8 +50,66 @@ def transactions():
         transactions = cursor.fetchall()
         cursor.close()
         conn.close()
+
     df = pd.DataFrame(transactions)
-    return render_template('transactions.html', transactions=df.to_dict(orient='records'))
+    columns = df.columns.tolist() if not df.empty else []
+    return render_template(
+        'transactions.html',
+        transactions=df.to_dict(orient='records'),
+        columns=columns,
+        zip_code=zip_code,
+        month=month,
+        year=year,
+    )
+
+
+@app.route('/visualize_transactions', methods=['POST'])
+def visualize_transactions():
+    zip_code = request.form.get('zip')
+    month = request.form.get('month')
+    year = request.form.get('year')
+    chart_type = request.form.get('chart_type')
+    x_col = request.form.get('x_col') or None
+    y_col = request.form.get('y_col') or None
+
+    transactions = []
+    if zip_code and month and year:
+        conn = connect_to_db()
+        cursor = conn.cursor(dictionary=True)
+        query = (
+            "SELECT cc.TRANSACTION_ID, cc.CREDIT_CARD_NO, cc.TIMEID,"
+            " cc.TRANSACTION_TYPE, cc.TRANSACTION_VALUE "
+            "FROM cdw_sapp_credit_card AS cc "
+            "JOIN cdw_sapp_customer AS cu ON cc.CREDIT_CARD_NO = cu.CREDIT_CARD_NO "
+            "WHERE cu.CUST_ZIP = %s AND MONTH(cc.TIMEID) = %s AND YEAR(cc.TIMEID) = %s "
+            "ORDER BY DAY(cc.TIMEID) DESC"
+        )
+        cursor.execute(query, (zip_code, int(month), int(year)))
+        transactions = cursor.fetchall()
+        cursor.close()
+        conn.close()
+
+    df = pd.DataFrame(transactions)
+    if df.empty:
+        return render_template('visualize.html', image=None)
+
+    fig = generate_visualization(df, chart_type, x_col, y_col)
+
+    log_folder = os.path.join(CAPSTONE_HOME, 'logs', 'visualizations')
+    os.makedirs(log_folder, exist_ok=True)
+    timestamp = datetime.datetime.now().strftime('%Y%m%d_%H%M%S')
+    filename = os.path.join(log_folder, f'web_viz_{timestamp}.png')
+    fig.savefig(filename)
+    plt.close(fig)
+    image_name = os.path.basename(filename)
+
+    return render_template('visualize.html', image=image_name)
+
+
+@app.route('/visualizations/<path:filename>')
+def visualization_file(filename):
+    folder = os.path.join(CAPSTONE_HOME, 'logs', 'visualizations')
+    return send_from_directory(folder, filename)
 
 
 @app.route('/monthly_bill', methods=['GET', 'POST'])

--- a/web/templates/transactions.html
+++ b/web/templates/transactions.html
@@ -17,6 +17,40 @@
             </tr>
             {% endfor %}
         </table>
+
+        <form action="{{ url_for('visualize_transactions') }}" method="post">
+            <input type="hidden" name="zip" value="{{ zip_code }}">
+            <input type="hidden" name="month" value="{{ month }}">
+            <input type="hidden" name="year" value="{{ year }}">
+
+            <label>Chart Type:</label>
+            <select name="chart_type">
+                <option value="bar">Bar Chart</option>
+                <option value="line">Line Chart</option>
+                <option value="scatter">Scatter Plot</option>
+                <option value="pie">Pie Chart</option>
+                <option value="hist">Histogram</option>
+                <option value="box">Box Plot</option>
+                <option value="heatmap">Heatmap</option>
+                <option value="grouped_bar">Grouped Bar Chart</option>
+            </select>
+
+            <label>X Column:</label>
+            <select name="x_col">
+                {% for col in columns %}
+                    <option value="{{ col }}">{{ col }}</option>
+                {% endfor %}
+            </select>
+
+            <label>Y Column:</label>
+            <select name="y_col">
+                {% for col in columns %}
+                    <option value="{{ col }}">{{ col }}</option>
+                {% endfor %}
+            </select>
+
+            <button type="submit">Visualize</button>
+        </form>
     {% else %}
         <p>No transactions found.</p>
     {% endif %}

--- a/web/templates/visualize.html
+++ b/web/templates/visualize.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block title %}Visualization{% endblock %}
+{% block content %}
+<h1>Visualization</h1>
+{% if image %}
+    <img src="{{ url_for('visualization_file', filename=image) }}" alt="Visualization">
+{% else %}
+    <p>No visualization available.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `generate_visualization` helper in `cli_app/visualizer.py`
- refactor CLI visualization flow to use the helper
- add routes for creating and serving visualizations in `web/app.py`
- update transactions page with visualization form
- add template to show generated visualizations

## Testing
- `python -m py_compile cli_app/visualizer.py web/app.py`

------
https://chatgpt.com/codex/tasks/task_e_684b42dbb6348324ae79e7192c139103