### PR TITLE
Add transactions range lookup

### DIFF
--- a/web/templates/home.html
+++ b/web/templates/home.html
@@ -22,6 +22,9 @@
     <h2>Monthly Bill</h2>
     <a href="/monthly_bill">Generate Monthly Bill</a>
 
+    <h2>Transactions by Date Range</h2>
+    <a href="/transactions_range">Search By Date Range</a>
+
     <h2>Modify Customer</h2>
     <a href="/modify_customer">Modify Customer Details</a>
 {% endblock %}

--- a/web/templates/transactions_range.html
+++ b/web/templates/transactions_range.html
@@ -1,0 +1,32 @@
+{% extends 'base.html' %}
+{% block title %}Transactions By Range{% endblock %}
+{% block content %}
+<h1>Transactions By Date Range</h1>
+<form method="get">
+    <label>Credit Card No:</label>
+    <input type="text" name="cc_num" required>
+    <label>Start Date:</label>
+    <input type="date" name="start_date" required>
+    <label>End Date:</label>
+    <input type="date" name="end_date" required>
+    <button type="submit">Search</button>
+</form>
+{% if transactions %}
+<table>
+    <tr>
+        {% for key in transactions[0].keys() %}
+            <th>{{ key }}</th>
+        {% endfor %}
+    </tr>
+    {% for row in transactions %}
+    <tr>
+        {% for value in row.values() %}
+        <td>{{ value }}</td>
+        {% endfor %}
+    </tr>
+    {% endfor %}
+</table>
+{% elif request.args %}
+<p>No transactions found.</p>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- create `/transactions_range` endpoint to search credit card transactions within a date range
- provide a new template for date range lookup results
- link to the new page from the home page

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b42da7f308324a88bd2ca4235fac3